### PR TITLE
Change base docker image to ruby:2.3.1-alpine; install gemstash 1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM ruby:2.3
+FROM ruby:2.3.1-alpine
 
-RUN gem install --no-ri --no-rdoc gemstash
+RUN apk add --no-cache make gcc musl-dev sqlite-libs sqlite-dev &&\
+  gem install --no-ri --no-rdoc gemstash --version 1.0.2
 
 CMD ["gemstash", "start", "--no-daemonize"]


### PR DESCRIPTION
Hi, thanks for a working docker image with Gemstash.

I would like to use Gemstash 1.0.2, because of a /versions checksum mismatch fixed: https://github.com/bundler/gemstash/issues/100 . Your image has Gemstash 1.0.0.

I also suggest using alpine as docker base image. I tested it as rubygems cache so far, not as gems server and it worked fine. Such an image takes 236.1MB instead of 740.5MB.

Any thoughts?
