### PR TITLE
changing run as to non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ruby:2.3
 
+RUN useradd -ms /bin/bash gemstash
+
 RUN gem install --no-ri --no-rdoc gemstash
+
+USER gemstash
 
 CMD ["gemstash", "start", "--no-daemonize"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Docker
 On the server:
 
 ```
-docker create -v /root/.gemstash --name gemstash_data artemave/gemstash
+mkdir -p /root/.gemstash
+docker create -v /root/.gemstash:/home/gemstash/.gemstash --name gemstash_data artemave/gemstash
 docker run -d -p '9292:9292' --restart=always --volumes-from gemstash_data --name gemstash_server artemave/gemstash
 ```
 


### PR DESCRIPTION
running as the root user in a container can present avenues towards container breakout, if a breakout happens from a container running as root, the bad actor will be mapped to root on the host system. While there are methods to map a containers root user to a restricted user on the host os, this is not enabled by default in the latest docker.

This change implements the best practice of creating a restricted user and running as it. 

One added benefit is should someone later shell into the container, they will be unable to make changes which would be lost should the container need to be recycled. 